### PR TITLE
Add capabilities to collect logs for duration of a specific container

### DIFF
--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu
+FROM ubuntu:16.04 
 LABEL maintainer="OpenEBS"
-RUN apt-get update || true
-RUN apt-get install -y curl libgetopt++-dev 
+RUN apt-get update || true \
+    && apt-get install -y curl libgetopt++-dev 
 ENV KUBE_LATEST_VERSION="v1.8.2"
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
  && chmod +x /usr/local/bin/kubectl 

--- a/logger/nodelogger.yaml
+++ b/logger/nodelogger.yaml
@@ -37,8 +37,8 @@ spec:
         - name: results 
           hostPath: 
             path: /mnt
-            type: Directory
+            type: "" 
         - name: root 
           hostPath: 
             path: /
-            type: Directory
+            type: ""


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

### Changes: 

- Logger can take a container as an argument & collect logs until it exists
- The node (systemd) logs are now stored inside the <test-specific> dir on hosts instead of /mnt
- Dockerfile updates (base image version changed to ubuntu:16.04)

### Notes: 

- The test container is placed in the logger entrypoint command specified in the jobs under the existing duration argument (-d)
- The pod name & namespace should be passed to the logger via ENV
- Example litmus jobs using these enhancements are described in https://github.com/openebs/litmus/pull/114



