### PR TITLE
Modified the custom liveness script

### DIFF
--- a/custom-liveness-client/custom-liveness.yml
+++ b/custom-liveness-client/custom-liveness.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: custom-liveness
+ 
+spec:
+  template:
+    metadata:
+      name: custom-liveness
+   
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: custom-liveness
+        image: openebs/custom-liveness
+        imagePullPolicy: Always
+
+        env: 
+
+            # Namespace in which application is running
+          - name: NAMESPACE
+            value: litmus
+    
+            # Service name of application
+          - name: SERVICE
+            value: pgset
+    
+            # Port on which application is listening
+          - name: PORT
+            value: "5432"   
+            
+             # Time period (in sec) b/w retries for DB init check
+          - name: INIT_WAIT_DELAY
+            value: "30"
+    
+            # No of retries for DB init check 
+          - name: INIT_RETRY_COUNT
+            value: "10"
+    
+            # Time period (in sec) b/w liveness checks
+          - name: LIVENESS_PERIOD_SECONDS
+            value: "10"
+    
+            # Time period (in sec) b/w retries for db_connect failure
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "10"
+    
+            # No of retries after a db_connect failure before declaring liveness fail
+          - name: LIVENESS_RETRY_COUNT
+            value: "6"  
+ 
+        command: ["/bin/bash"]
+        args: ["-c", "python ./liveness.py ; exit 0"]

--- a/custom-liveness-client/liveness.py
+++ b/custom-liveness-client/liveness.py
@@ -4,6 +4,11 @@ import time
 import os
 
 # Assigning the environment variables
+i_w_d = os.environ['INIT_WAIT_DELAY']   # Time period (in sec) b/w retries for DB init check
+i_r_c = os.environ['INIT_RETRY_COUNT']      # No of retries for DB init check
+l_p_s = os.environ['LIVENESS_PERIOD_SECONDS'] # Time period (in sec) b/w liveness checks
+l_t_s = os.environ['LIVENESS_TIMEOUT_SECONDS']  # Time period (in sec) b/w retries for db_connect failure
+l_r_c = os.environ['LIVENESS_RETRY_COUNT'] # No of retries after a db_connect failure before declaring liveness fail
 port = os.environ['PORT']
 ns = os.environ['NAMESPACE']
 sv = os.environ['SERVICE']
@@ -16,17 +21,52 @@ def isOpen(ip,port):
        return True
     except:
        return False
+
+
+def database_check(ip,port):
+    for i in range(1,int(i_r_c)):
+        x=isOpen(ip,port)
+        if x==False:
+            isOpen(ip,port)
+            print("fail", flush=True)
+            # sys.stdout.flush()
+        else:
+            print("pass", x,flush=True)
+            # sys.stdout.flush()
+            break
+    time.sleep(int(i_w_d))
+
+
+def retryConnection(ip,port):
+    print("Retrying to establish connection",flush=True)
+    for y in range(1,int(l_r_c)):
+       z=isOpen(ip,port)
+       if z==True:
+           return z
+       time.sleep(int(l_t_s))
+    if z==False:
+        return z   
+
+
+def liveness(ip,port):
+    while True:    
+        res=isOpen(ip,port)
+        if res==True:
+            print ("Liveness Running",flush=True)
+            sys.stdout.flush()
+        else:
+            print("Liveness Failed",flush=True)
+            sys.stdout.flush()
+            z=retryConnection(ip,port)
+            if z==False:
+                print("Liveness finally failed:",flush=True)
+                break
+        time.sleep(int(l_p_s))
+
   
 if __name__ == '__main__':
     url = sv+"."+ns+"."+"svc.cluster.local"
     ip= url
     port=int(port)
-    while True:    
-        res=isOpen(ip,port)
-        if res==True:
-            print ("Liveness Running")
-            sys.stdout.flush()
-        else:
-            print("Liveness Failed")
-            sys.stdout.flush()
-        time.sleep(4)
+    database_check(ip,port)
+    liveness(ip,port)


### PR DESCRIPTION
This commit does the following:
- Changes the custom-liveness script in order to work like a standard liveness script in which following considerations have been taken:
1.INIT_WAIT_DELAY
2.INIT_RETRY_COUNT
3.LIVENESS_PERIOD_SECONDS
4.LIVENESS_TIMEOUT_SECONDS
5.LIVENESS_RETRY_COUNT
- Now this script is able to accept liveness-specific params as an ENV-VAR.