### PR TITLE
fix(dockerfile): remove apt-upgrade step from the postgres-client docker build

### DIFF
--- a/postgres-client/Dockerfile
+++ b/postgres-client/Dockerfile
@@ -3,12 +3,10 @@ FROM postgres:latest
 ADD /workloads/test.sh /
 ADD /liveness/liveness.py /
  
-#RUN apt-get upgrade
 RUN apt-get update && apt-get -y --force-yes install --no-install-recommends     \
     expect                                                  \
     python3                                             \
     python-pip                                                  
-RUN apt-get upgrade
 RUN pip install psycopg2
 RUN python -m pip install psycopg2-binary
 RUN chmod +x ./test.sh


### PR DESCRIPTION
- The 'update' step is need in order to install necessary packages
- 'upgrade' seems to stall the travis build (timeout) 

Signed-off-by: ksatchit <karthik.s@openebs.io>