### PR TITLE
refactor(bash): increase retry count for database init check on mysql

### DIFF
--- a/tpcc-client/tpcc-mysql/tpcc-runner.sh
+++ b/tpcc-client/tpcc-mysql/tpcc-runner.sh
@@ -30,7 +30,7 @@ fi
 # interval    : ${T_P[6]}
 
 echo -e "\nWaiting for mysql server to start accepting connections.."
-retries=10;wait_retry=30
+retries=30;wait_retry=30
 for i in `seq 1 $retries`; do 
   mysql -h $DB_SERVER_IP -u${T_P[0]} -p${T_P[1]} -e 'status' > /dev/null 2>&1
   rc=$?


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- The percona db-init check sometimes takes longer depending upon the underlying storage. Setting a slightly larger upper-bound for the db init wait time 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
