### PR TITLE
fix(mysql_client): fixing timeout command parameters

### DIFF
--- a/mysql-client/mysql-liveness-check.sh
+++ b/mysql-client/mysql-liveness-check.sh
@@ -53,7 +53,7 @@ $(($I_R_C * $I_W_D))s, exiting"
 # Kill the query after 1s if hung/stuck (typically seen w/ disconnects) 
 liveness_check()
 {
- timeout 1 mysql -h $1 -u$2 -p$3 -e 'select 1' > /dev/null 2>&1  
+ timeout -t 5 mysql -h $1 -u$2 -p$3 -e 'select 1' > /dev/null 2>&1
  rc=$?
 }
 


### PR DESCRIPTION
mysql-client uses 'timeout' command to check the liveness of the percona application. Due to wrong parameters for 'timeout' command, it always returns error.

This PR is to fix the parameters of timeout command, and, to have 5 seconds as timeout value.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>