### PR TITLE
refactor(bash)(liveness): enhance mysql liveness script

### DIFF
--- a/mysql-client/db-cred.cnf
+++ b/mysql-client/db-cred.cnf
@@ -1,5 +1,0 @@
-{
-  "db_server_ip": "10.105.68.234",
-  "db_user": "root",
-  "db_password": "k8sDem0"
-}

--- a/mysql-client/mysql-liveness-check.yaml
+++ b/mysql-client/mysql-liveness-check.yaml
@@ -24,34 +24,38 @@ spec:
   - name: mysql-liveness-check
     image: openebs/tests-mysql-client
     env:
-        # Time period (in sec) b/w retries for DB init check
+      # Time period (in sec) b/w retries for DB init check
       - name: INIT_WAIT_DELAY
         value: "30"
 
-        # No of retries for DB init check 
+      # No of retries for DB init check 
       - name: INIT_RETRY_COUNT
         value: "10"
 
-        # Time period (in sec) b/w liveness checks
+      # Time period (in sec) b/w liveness checks
       - name: LIVENESS_PERIOD_SECONDS
         value: "10"
 
-        # Time period (in sec) b/w retries for db_connect failure
+      # Time period (in sec) b/w retries for db_connect failure
       - name: LIVENESS_TIMEOUT_SECONDS
         value: "10"
 
-        # No of retries after a db_connect failure before declaring liveness fail
+      # No of retries after a db_connect failure before declaring liveness fail
       - name: LIVENESS_RETRY_COUNT
         value: "6"
 
+      # Application service name
+      - name: DB_SVC 
+        value: percona-mysql.default.svc.cluster.local
+         
+      # Database username
+      - name: DB_USER
+        value: root
+
+      # Database password
+      - name: DB_PASSWORD
+        value: k8sDem0
+
     command: ["/bin/bash"]
-    args: ["-c", "bash mysql-liveness-check.sh db-cred.cnf ; exit 0"]
+    args: ["-c", "bash mysql-liveness-check.sh; exit 0"]
     tty: true 
-    volumeMounts:
-      - mountPath: /db-cred.cnf
-        subPath: db-cred.cnf
-        name: db-cred
-  volumes:
-    - name: db-cred
-      configMap:
-        name: db-cred  


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Enhances the mysql liveness script & K8s job: 

- Accept database credentials from env instead of a conf file
- Use timeout for database init check
- Update usage to segregate mandatory & optional env
- Update K8s liveness job with new env, service fqdn & entrypoint


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
