### PR TITLE
(refactor)(docker): update custom-percona image to latest version & include liveness script

### DIFF
--- a/custom-percona/Dockerfile
+++ b/custom-percona/Dockerfile
@@ -122,7 +122,7 @@ RUN wget https://repo.percona.com/apt/percona-release_0.1-6.$(lsb_release -sc)_a
     && dkpg -i percona-release_0.1-6.$(lsb_release -sc)_all.deb || true \
     && apt-get install -y -f
 
-RUN apt-get update && apt-get install pmm-client
+RUN apt-get update && apt-get install -y pmm-client procps
 # End of changes to include pmm-client
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]

--- a/custom-percona/Dockerfile
+++ b/custom-percona/Dockerfile
@@ -1,27 +1,55 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie
+FROM debian:stretch
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -ex; \
+	apt-get update; \
+	if ! which gpg; then \
+		apt-get install -y --no-install-recommends gnupg; \
+	fi; \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	if ! gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
+		 apt-get install -y --no-install-recommends dirmngr; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+	\
+	fetchDeps=' \
+		ca-certificates \
+		wget \
+	'; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
+	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu nobody true; \
+	\
+	apt-get purge -y --auto-remove $fetchDeps
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
 # install "apt-transport-https" for Percona's repo (switched to https-only)
+# install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		apt-transport-https ca-certificates \
 		pwgen \
@@ -41,20 +69,23 @@ ENV GPG_KEYS \
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+		gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done; \
-	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/percona.gpg; \
+	gpg --batch --export $GPG_KEYS > /etc/apt/trusted.gpg.d/percona.gpg; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
+RUN echo 'deb https://repo.percona.com/apt stretch main' > /etc/apt/sources.list.d/percona.list
 
+# bashbrew-architectures: amd64
 ENV PERCONA_MAJOR 5.7
-ENV PERCONA_VERSION 5.7.21-20-1.jessie
+ENV PERCONA_VERSION 5.7.23-24-1.stretch
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
-RUN { \
+RUN set -ex; \
+	{ \
 		for key in \
 			percona-server-server/root_password \
 			percona-server-server/root_password_again \
@@ -63,42 +94,45 @@ RUN { \
 		; do \
 			echo "percona-server-server-$PERCONA_MAJOR" "$key" password 'unused'; \
 		done; \
-	} | debconf-set-selections \
-	&& apt-get update \
-	&& apt-get install -y \
+	} | debconf-set-selections; \
+	apt-get update; \
+	apt-get install -y \
 		percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION \
-	&& rm -rf /var/lib/apt/lists/* \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
-	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
+	sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf; \
 # purge and re-create /var/lib/mysql with appropriate ownership
-	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
-	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+	rm -rf /var/lib/mysql; \
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld; \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
-
+	chmod 777 /var/run/mysqld; \
 # comment out a few problematic configuration values
-# don't reverse lookup hostnames, they are usually another container
-RUN \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
-	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
-
-VOLUME ["/var/lib/mysql", "/var/log/mysql"]
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/'; \
+# don't reverse lookup hostnames, they are usually another container
+	echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 # Start of changes to include pmm-client
-RUN apt-get update && apt-get install -y wget dpkg 
+RUN apt-get update && apt-get install -y wget dpkg
 
-RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb \
-    && dkpg -i percona-release_0.1-4.jessie_all.deb || true \ 
+RUN wget https://repo.percona.com/apt/percona-release_0.1-6.$(lsb_release -sc)_all.deb \
+    && dkpg -i percona-release_0.1-6.$(lsb_release -sc)_all.deb || true \
     && apt-get install -y -f
 
 RUN apt-get update && apt-get install pmm-client
 # End of changes to include pmm-client
 
+VOLUME ["/var/lib/mysql", "/var/log/mysql"]
+
 COPY docker-entrypoint.sh /usr/local/bin/
+# Add the liveness script
+COPY sql-test.sh /
+ 
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 EXPOSE 3306
 CMD ["mysqld"]

--- a/custom-percona/docker-entrypoint.sh
+++ b/custom-percona/docker-entrypoint.sh
@@ -63,7 +63,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
 	_check_config "$@"
 	DATADIR="$(_datadir "$@")"
 	mkdir -p "$DATADIR"
-	chown -R mysql:mysql "$DATADIR"
+	find "$DATADIR" \! -user mysql -exec chown mysql '{}' +
 	exec gosu mysql "$BASH_SOURCE" "$@"
 fi
 
@@ -113,14 +113,28 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			export MYSQL_ROOT_PASSWORD="$(pwgen -1 32)"
 			echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi
+
+		rootCreate=
+		# default root to listen for connections from anywhere
+		file_env 'MYSQL_ROOT_HOST' '%'
+		if [ ! -z "$MYSQL_ROOT_HOST" -a "$MYSQL_ROOT_HOST" != 'localhost' ]; then
+			# no, we don't care if read finds a terminating character in this heredoc
+			# https://unix.stackexchange.com/questions/265149/why-is-set-o-errexit-breaking-this-read-heredoc-expression/265151#265151
+			read -r -d '' rootCreate <<-EOSQL || true
+				CREATE USER 'root'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+				GRANT ALL ON *.* TO 'root'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
+			EOSQL
+		fi
+
 		"${mysql[@]}" <<-EOSQL
 			-- What's done in this file shouldn't be replicated
 			--  or products like mysql-fabric won't work
 			SET @@SESSION.SQL_LOG_BIN=0;
 
-			DELETE FROM mysql.user ;
-			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+			DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mysqlxsys', 'root') OR host NOT IN ('localhost') ;
+			SET PASSWORD FOR 'root'@'localhost'=PASSWORD('${MYSQL_ROOT_PASSWORD}') ;
+			GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
+			${rootCreate}
 			DROP DATABASE IF EXISTS test ;
 			FLUSH PRIVILEGES ;
 		EOSQL

--- a/custom-percona/sql-test.sh
+++ b/custom-percona/sql-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+DB_PREFIX="Inventory"
+DB_SUFFIX=`echo $(mktemp) | cut -d '.' -f 2`
+DB_NAME="${DB_PREFIX}_${DB_SUFFIX}"
+
+
+echo -e "\nWaiting for mysql server to start accepting connections.."
+retries=10;wait_retry=60
+for i in `seq 1 $retries`; do
+  mysql -uroot -pk8sDem0 -e 'status' > /dev/null 2>&1
+  rc=$?
+  [ $rc -eq 0 ] && break
+  sleep $wait_retry
+done
+
+if [ $rc -ne 0 ];
+then
+  echo -e "\nFailed to connect to db server after trying for $(($retries * $wait_retry))s, exiting\n"
+  exit 1
+fi
+mysql -uroot -pk8sDem0 -e "CREATE DATABASE $DB_NAME;"
+mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" $DB_NAME
+mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" $DB_NAME
+mysql -uroot -pk8sDem0 -e "DROP DATABASE $DB_NAME;"


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Percona no longer uses debian:jessie as the base image. It is updated w/ latest (debian:stretch)
- Update the entrypoint script as per latest 5.7 percona minor version
- Include liveness script to be used as a K8s liveness probe

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
