### PR TITLE
(refactor)(image): enhance liveness load w/ DB CRUD operations 

### DIFF
--- a/custom-percona/Dockerfile
+++ b/custom-percona/Dockerfile
@@ -80,7 +80,7 @@ RUN echo 'deb https://repo.percona.com/apt stretch main' > /etc/apt/sources.list
 
 # bashbrew-architectures: amd64
 ENV PERCONA_MAJOR 5.7
-ENV PERCONA_VERSION 5.7.23-24-1.stretch
+ENV PERCONA_VERSION 5.7.23-25-1.stretch
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
@@ -130,6 +130,7 @@ VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 COPY docker-entrypoint.sh /usr/local/bin/
 # Add the liveness script
 COPY sql-test.sh /
+COPY mysqld.cnf /etc/mysql/percona-server.conf.d/
  
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/custom-percona/mysqld.cnf
+++ b/custom-percona/mysqld.cnf
@@ -1,0 +1,34 @@
+#
+# The Percona Server 5.7 configuration file.
+#
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[mysqld]
+user   = mysql
+pid-file = /var/run/mysqld/mysqld.pid
+socket   = /var/run/mysqld/mysqld.sock
+port   = 3306
+basedir    = /usr
+datadir    = /var/lib/mysql
+tmpdir   = /tmp
+lc-messages-dir  = /usr/share/mysql
+explicit_defaults_for_timestamp
+
+#log-error    = /var/log/mysql/error.log
+
+# Recommended in standard MySQL setup
+sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+# O_DIRECT: InnoDB uses O_DIRECT (or directio() on Solaris) to open the data files, 
+# and uses fsync() to flush both the data and log files. This option is available on some 
+# GNU/Linux versions, FreeBSD, and Solaris.
+ 
+innodb_flush_method=O_DIRECT

--- a/custom-percona/sql-test.sh
+++ b/custom-percona/sql-test.sh
@@ -19,7 +19,27 @@ then
   echo -e "\nFailed to connect to db server after trying for $(($retries * $wait_retry))s, exiting\n"
   exit 1
 fi
+
+## DB CREATE 
 mysql -uroot -pk8sDem0 -e "CREATE DATABASE $DB_NAME;"
 mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" $DB_NAME
-mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" $DB_NAME
+
+## DB WRITE
+for i in {1..100}; do 
+  tvalue=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 18 | head -n 3`; arr=($tvalue)
+  mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (${i}, "${arr[0]}", "${arr[1]}", "${arr[2]}");" $DB_NAME
+  sync; 
+done
+
+## DB UPDATE
+for i in {1..50}; do
+  mysql -uroot -pk8sDem0 -e "UPDATE Hardware SET description ="master" WHERE id = $i;" $DB_NAME 
+  sync; 
+done
+
+## DB PARALLEL READ/WRITE
+mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware SELECT * FROM Hardware;" $DB_NAME 
+
+## DB DESTROY
 mysql -uroot -pk8sDem0 -e "DROP DATABASE $DB_NAME;"
+sync; 


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Increase efficiency of the liveness script by performing CRUD on percona DB instead of just simple table write/drop database
- Use innodb_flush_method to O_DIRECT (base image debian:stretch supports it) in order to perform unbuffered I/O for log writes
- Perform `sync` after write ops to ensure data in client fs is pushed to persistent disk
- Update percona MINOR_VERSION 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- `sync_binlog=1` is a surer way to flush every transaction's data to disk (along w/ the `innodb_flush_log_at_trx_commit=1`, which is default). However, this is seen to cause a highly delayed DB init (system databases bringup), and hence may not be useful in the context of CI pipelines. 
- Use manual `sync` commands instead 
