### PR TITLE
Added busybox client for liveness

### DIFF
--- a/busybox/Dockerfile
+++ b/busybox/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest
+RUN apk add -U curl bash
+#RUN apt-get update
+#RUN apt -y install curl
+#RUN curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+#RUN chmod +x kubectl
+RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl && \
+  chmod +x /usr/bin/kubectl && \
+kubectl version --client
+COPY liveness.sh /
+
+CMD ["/liveness.sh"]

--- a/busybox/liveness.sh
+++ b/busybox/liveness.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+liveness_cmd='kubectl exec -it $POD_NAME -n $NAMESPACE -- sh -c "cd /busybox && dd if=/dev/urandom of=test.txt bs=4k count=1024 && echo "test" >> test.txt && cat test.txt | grep test && rm test.txt"'
+
+retry=0
+
+while (true); do
+
+if [ "$retry" == "$LIVENESS_RETRY_COUNT" ]; then
+  break;
+fi
+
+eval $liveness_cmd >/dev/null # '>/dev/null will supress the output of the commnad
+
+if [ "$?" == 0 ]; then
+  echo "liveness-running"
+  sleep $LIVENESS_TIMEOUT_SECONDS
+else
+  echo "livenes-failed"
+  sleep $LIVENESS_TIMEOUT_SECONDS
+  retry=$((retry+1))  
+fi
+done
+


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a busybox liveness script with associated Dockerfile.
- `liveness.sh` performs **CRUD** operation on busybox and for each CRUD-iteration it sets liveness running.
- `liveness.sh` takes pod-name, namespace, liveness_timeout, liveness_retry_count as environment variable.
**Following the log of the liveness-container**
```
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.431196 seconds, 92.8MB/s
liveness-running
Unable to use a TTY - input is not a terminal or the right kind of file
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.395782 seconds, 101.1MB/s
liveness-running
Unable to use a TTY - input is not a terminal or the right kind of file
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.394063 seconds, 101.5MB/s
liveness-running
Unable to use a TTY - input is not a terminal or the right kind of file
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.545244 seconds, 73.4MB/s
liveness-running
```
